### PR TITLE
[DRY] baseurl into client

### DIFF
--- a/pipedrive/data_source_deals.go
+++ b/pipedrive/data_source_deals.go
@@ -31,7 +31,8 @@ func dataSourceDealsRead(ctx context.Context, d *schema.ResourceData, m interfac
 	client := &http.Client{Timeout: 10 * time.Second}
 	id := d.Get("id").(string)
 	apikey := m.(*Client).apitoken
-	apiurl := fmt.Sprintf("https://api.pipedrive.com/v1/deals/%s?api_token=%s", id, apikey)
+	baseurl := m.(*Client).baseurl
+	apiurl := fmt.Sprintf("%s/deals/%s%s", baseurl, id, apikey)
 
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics

--- a/pipedrive/provider.go
+++ b/pipedrive/provider.go
@@ -30,11 +30,13 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 type Client struct {
 	apitoken string
+	baseurl  string
 }
 
 // NewClient creates common settings
 func NewClient(apitoken string) *Client {
 	return &Client{
-		apitoken: apitoken,
+		apitoken: "?api_token=" + apitoken,
+		baseurl:  "https://api.pipedrive.com/v1",
 	}
 }


### PR DESCRIPTION
This PR inserts the baseurl to the API in the struct that creates the api-client.