### PR TITLE
DRYing of client settings for resources

### DIFF
--- a/pipedrive/client.go
+++ b/pipedrive/client.go
@@ -1,0 +1,91 @@
+package pipedrive
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// NewClient creates common settings
+func NewClient(apitoken string) *Client {
+	return &Client{
+		apitoken:   "?api_token=" + apitoken,
+		baseurl:    "https://api.pipedrive.com/v1/",
+		httpClient: &http.Client{},
+	}
+}
+
+func DealsBody(d *schema.ResourceData) DealsBodyPost {
+	body := DealsBodyPost{
+		Title: d.Get("title").(string),
+		OrgID: d.Get("org_id").(string),
+	}
+
+	status, status_true := d.GetOk("status")
+
+	if status_true {
+		body.Status = status.(string)
+	}
+
+	return body
+}
+
+func NotesBody(d *schema.ResourceData) NotesBodyPost {
+	body := NotesBodyPost{
+		Content: d.Get("content").(string),
+		DealID:  d.Get("deal_id").(string),
+	}
+
+	return body
+}
+
+func (c *Client) SendRequest(method string, path string, payload interface{}, statusCode int) (value string, respheaders string, respCode int, err error) {
+	apiurl := c.baseurl + path + c.apitoken
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	b := new(bytes.Buffer)
+	err = json.NewEncoder(b).Encode(payload)
+	if err != nil {
+		return "", "", 0, err
+	}
+
+	req, err := http.NewRequest(method, apiurl, b)
+	if err != nil {
+		return "", "", 0, err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", resp.StatusCode, err
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", resp.StatusCode, err
+	}
+	resp.Body.Close()
+
+	strbody := string(body)
+
+	respHeaders := resp.Header
+	headers, err := json.Marshal(respHeaders)
+	if err != nil {
+		return "", "", resp.StatusCode, err
+	}
+
+	if statusCode != 0 {
+		if resp.StatusCode != statusCode {
+			return "", "", 0, fmt.Errorf("[ERROR] unexpected status code got: %v expected: %v \n %v", resp.StatusCode, statusCode, strbody)
+		}
+	}
+
+	return strbody, string(headers), resp.StatusCode, nil
+}

--- a/pipedrive/models.go
+++ b/pipedrive/models.go
@@ -1,0 +1,22 @@
+package pipedrive
+
+import (
+	"net/http"
+)
+
+type DealsBodyPost struct {
+	Title  string `json:"title,omitempty"`
+	OrgID  string `json:"org_id,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+type Client struct {
+	apitoken   string "omitempty"
+	baseurl    string "omitempty"
+	httpClient *http.Client
+}
+
+type NotesBodyPost struct {
+	Content string `json:"content,omitempty"`
+	DealID  string `json:"deal_id,omitempty"`
+}

--- a/pipedrive/provider.go
+++ b/pipedrive/provider.go
@@ -1,13 +1,6 @@
 package pipedrive
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -38,100 +31,4 @@ func Provider() *schema.Provider {
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	apitoken := d.Get("apikey").(string)
 	return NewClient(apitoken), nil
-}
-
-type Client struct {
-	apitoken   string "omitempty"
-	baseurl    string "omitempty"
-	httpClient *http.Client
-}
-
-// NewClient creates common settings
-func NewClient(apitoken string) *Client {
-	return &Client{
-		apitoken:   "?api_token=" + apitoken,
-		baseurl:    "https://api.pipedrive.com/v1",
-		httpClient: &http.Client{},
-	}
-}
-
-func (c *Client) SendRequest(method string, path string, payload interface{}, statusCode int) (value string, respheaders string, respCode int, err error) {
-	apiurl := c.baseurl + "/" + path + c.apitoken
-	client := &http.Client{}
-
-	b := new(bytes.Buffer)
-	err = json.NewEncoder(b).Encode(payload)
-	if err != nil {
-		return "", "", 0, err
-	}
-
-	req, err := http.NewRequest(method, apiurl, b)
-	if err != nil {
-		return "", "", 0, err
-	}
-
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", "", resp.StatusCode, err
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", "", resp.StatusCode, err
-	}
-	resp.Body.Close()
-
-	strbody := string(body)
-
-	respHeaders := resp.Header
-	headers, err := json.Marshal(respHeaders)
-	if err != nil {
-		return "", "", resp.StatusCode, err
-	}
-
-	if statusCode != 0 {
-		if resp.StatusCode != statusCode {
-
-			return "", "", 0, fmt.Errorf("[ERROR] unexpected status code got: %v expected: %v \n %v", resp.StatusCode, statusCode, strbody)
-		}
-	}
-
-	return strbody, string(headers), resp.StatusCode, nil
-}
-
-func DealsBody(d *schema.ResourceData) *strings.Reader {
-	result := ""
-	resultstart := `{`
-	resultend := `}`
-
-	title, title_true := d.GetOk("title")
-	status, status_true := d.GetOk("status")
-	org_id, org_id_true := d.GetOk("org_id")
-	content, content_true := d.GetOk("content")
-	deal_id, deal_id_true := d.GetOk("deal_id")
-
-	if title_true {
-		result += `"title": "` + title.(string) + `",`
-	}
-	if status_true {
-		result += `"status": "` + status.(string) + `",`
-	}
-	if org_id_true {
-		result += `"org_id": "` + org_id.(string) + `",`
-	}
-	if content_true {
-		result += `"content": "` + content.(string) + `",`
-	}
-	if deal_id_true {
-		result += `"deal_id": "` + deal_id.(string) + `",`
-	}
-
-	result = strings.TrimSuffix(result, ",")
-	result = resultstart + result + resultend
-	returnresult := strings.NewReader(result)
-
-	return returnresult
 }

--- a/pipedrive/resource_deals.go
+++ b/pipedrive/resource_deals.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -56,30 +54,18 @@ func resourceDeals() *schema.Resource {
 }
 
 func resourceDealsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := &http.Client{Timeout: 10 * time.Second}
-	apikey := m.(*Client).apitoken
-	baseurl := m.(*Client).baseurl
-	apiurl := fmt.Sprintf("%s/deals%s", baseurl, apikey)
-	payload := DealsBody(d)
-
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
+	path := "deals"
+	body := DealsBody(d)
+	resp, _, _, err := m.(*Client).SendRequest("POST", path, body, 201)
 
-	req, err := http.NewRequest("POST", apiurl, payload)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
-
-	r, err := client.Do(req)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	defer r.Body.Close()
 
 	var result map[string]any
-	err = json.NewDecoder(r.Body).Decode(&result)
+	err = json.Unmarshal([]byte(resp), &result)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -95,31 +81,18 @@ func resourceDealsCreate(ctx context.Context, d *schema.ResourceData, m interfac
 }
 
 func resourceDealsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := &http.Client{Timeout: 10 * time.Second}
-	id := d.Id()
-	apikey := m.(*Client).apitoken
-	baseurl := m.(*Client).baseurl
-	apiurl := fmt.Sprintf("%s/deals/%s%s", baseurl, id, apikey)
-
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
-	req, err := http.NewRequest("GET", apiurl, nil)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	id := d.Id()
+	path := "deals/" + id
+	resp, _, _, err := m.(*Client).SendRequest("GET", path, nil, 200)
 
-	r, err := client.Do(req)
-	if r.StatusCode == 404 && err != nil {
-		d.SetId("")
-		diag.FromErr(err)
-	}
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	defer r.Body.Close()
 
 	var result map[string]any
-	err = json.NewDecoder(r.Body).Decode(&result)
+	err = json.Unmarshal([]byte(resp), &result)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -136,54 +109,31 @@ func resourceDealsRead(ctx context.Context, d *schema.ResourceData, m interface{
 }
 
 func resourceDealsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := &http.Client{Timeout: 10 * time.Second}
 	id := d.Id()
-	apikey := m.(*Client).apitoken
-	baseurl := m.(*Client).baseurl
-	apiurl := fmt.Sprintf("%s/deals/%s%s", baseurl, id, apikey)
-	payload := DealsBody(d)
-
-	req, err := http.NewRequest("PUT", apiurl, payload)
+	path := "deals/" + id
+	body := DealsBody(d)
+	_, _, _, err := m.(*Client).SendRequest("PUT", path, body, 200)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
-
-	r, err := client.Do(req)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	defer r.Body.Close()
 
 	return resourceDealsRead(ctx, d, m)
-
 }
 
 func resourceDealsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	client := &http.Client{Timeout: 10 * time.Second}
-	id := d.Id()
-	apikey := m.(*Client).apitoken
-	baseurl := m.(*Client).baseurl
-	apiurl := fmt.Sprintf("%s/deals/%s%s", baseurl, id, apikey)
-
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
-	req, err := http.NewRequest("DELETE", apiurl, nil)
+	id := d.Id()
+	path := "deals/" + id
+	resp, _, _, err := m.(*Client).SendRequest("DELETE", path, nil, 200)
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	r, err := client.Do(req)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	defer r.Body.Close()
 
 	var result map[string]any
-	err = json.NewDecoder(r.Body).Decode(&result)
+	err = json.Unmarshal([]byte(resp), &result)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
This PR DRY up the code of client-settings in resources.
This PR sets up `client.go` and `models.go` for easier modelling for the future.